### PR TITLE
feat(mobile): onboarding vocab assessment — skeleton + flow (SPEC-INPUT-003 Phase 5)

### DIFF
--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -42,14 +42,21 @@ import { trackEvent } from "@/lib/analytics";
 import { inferPremiumPreferredSourceTypes } from "@/lib/premium-interest-clusters";
 import { useTheme, createThemedStyles } from "@/components/ui";
 import { mediaOverlay } from "@inputenglish/design-tokens";
+import { VocabAssessment } from "@/components/onboarding/VocabAssessment";
+import { submitVocabAssessment } from "@/lib/premium-api";
+import type { VocabAnswer } from "@/lib/premium-api";
 
-type OnboardingStep = "level" | "goal" | "details" | "preparing";
+type OnboardingStep = "vocab" | "level" | "goal" | "details" | "preparing";
+// @MX:NOTE: "vocab" is the primary first step — a Yes/No vocab-size test
+//           (SPEC-INPUT-003) that measures the user's band instead of the
+//           self-reported 4-choice. "level" is kept as an off-sequence
+//           fallback reached by skipping the test (abandonment, I-W1).
 // @MX:NOTE: Speaking/pronunciation is feature-gated on main until the
 //           Azure + ffmpeg pipeline on feature/speaking-stability is
 //           stable. The "goal" step is dropped because "expression" is
 //           the only selectable goal_mode right now; re-insert it here
 //           when speaking returns.
-const STEP_SEQUENCE: OnboardingStep[] = ["level", "details", "preparing"];
+const STEP_SEQUENCE: OnboardingStep[] = ["vocab", "details", "preparing"];
 
 const LEVEL_OPTIONS: Array<{ value: LearningLevelBand; label: string }> = [
   { value: "beginner", label: "거의 한 마디도 못해요" },
@@ -477,6 +484,12 @@ const getScreenStyles = createThemedStyles((theme) => ({
   screen: {
     flex: 1,
   },
+  vocabContainer: {
+    flex: 1,
+    paddingHorizontal: theme.spacing[4],
+    paddingTop: theme.spacing[4],
+    paddingBottom: theme.spacing[6],
+  },
   content: {
     flexGrow: 1,
     paddingHorizontal: theme.spacing[4],
@@ -600,10 +613,15 @@ export default function OnboardingScreen() {
     useAuth();
   const { width: viewportWidth } = useWindowDimensions();
   const isEditMode = edit === "1";
-  const [step, setStep] = useState<OnboardingStep>("level");
+  // Fresh onboarding starts with the vocab test; edit mode jumps straight to
+  // the manual level picker (no need to re-measure on a profile edit).
+  const [step, setStep] = useState<OnboardingStep>(
+    isEditMode ? "level" : "vocab",
+  );
   const [transitionDirection, setTransitionDirection] = useState<1 | -1>(1);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [level, setLevel] = useState<LearningLevelBand | null>(null);
+  const [vocabSubmitting, setVocabSubmitting] = useState(false);
   // @MX:NOTE: Pronunciation mode is feature-gated — default to expression
   //           on main while speaking stability work continues on the
   //           feature/speaking-stability branch.
@@ -804,13 +822,55 @@ export default function OnboardingScreen() {
     stepTransition.setValue(1);
   }, [stepTransition]);
 
+  // @MX:NOTE: Vocab test completion (SPEC-INPUT-003 I-E1). The server scores +
+  //           persists user_vocab_profiles + seed known_words and returns the
+  //           estimated band, which seeds the manual `level` state so the
+  //           profile save stays consistent. On failure, fall back to the
+  //           manual level picker (abandonment-safe, I-W1).
+  const handleVocabComplete = async (answers: VocabAnswer[]) => {
+    if (vocabSubmitting) return;
+    setVocabSubmitting(true);
+    try {
+      const result = await submitVocabAssessment(answers);
+      // VocabBand and LearningLevelBand share the same 4 values.
+      setLevel(result.estimatedBand as LearningLevelBand);
+      trackEvent("onboarding_vocab_assessed", {
+        band: result.estimatedBand,
+        level: result.estimatedLevel,
+        seedCount: result.seedCount,
+      });
+      transitionToStep("details");
+    } catch (error) {
+      console.error("[Onboarding] vocab assessment failed:", error);
+      // Abandonment / failure → manual level fallback (no garbage persisted).
+      transitionToStep("level");
+    } finally {
+      setVocabSubmitting(false);
+    }
+  };
+
+  const handleVocabSkip = () => {
+    if (vocabSubmitting) return;
+    trackEvent("onboarding_vocab_skipped", {});
+    transitionToStep("level");
+  };
+
   const handleBack = () => {
-    if (isSaving || step === "preparing") return;
+    if (isSaving || step === "preparing" || vocabSubmitting) return;
 
     if (step === "details") {
-      // Goal step is skipped while speaking is gated — go straight back
-      // to level.
-      transitionToStep("level");
+      transitionToStep(isEditMode ? "level" : "vocab");
+      return;
+    }
+
+    if (step === "level") {
+      // Manual picker is the skip fallback from the vocab test. In edit mode
+      // it is the first step, so back exits the flow.
+      if (isEditMode) {
+        router.back();
+      } else {
+        transitionToStep("vocab");
+      }
       return;
     }
 
@@ -1052,96 +1112,124 @@ export default function OnboardingScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.screen}>
-        <ScrollView
-          contentContainerStyle={[
-            styles.content,
-            step !== "preparing" && styles.contentWithFooter,
-          ]}
-          showsVerticalScrollIndicator={false}
-        >
-          <View style={styles.headerRow}>
-            <Pressable
-              accessibilityLabel="이전"
-              onPress={handleBack}
-              style={({ pressed }) => [
-                styles.backButton,
-                pressed && styles.backButtonPressed,
+        {step === "vocab" ? (
+          <View style={styles.vocabContainer}>
+            <View style={styles.headerRow}>
+              <Pressable
+                accessibilityLabel="이전"
+                onPress={handleBack}
+                style={({ pressed }) => [
+                  styles.backButton,
+                  pressed && styles.backButtonPressed,
+                ]}
+              >
+                <Ionicons
+                  name="arrow-back"
+                  size={22}
+                  color={theme.colors.text.primary}
+                />
+              </Pressable>
+            </View>
+            <VocabAssessment
+              onComplete={handleVocabComplete}
+              onSkip={handleVocabSkip}
+              submitting={vocabSubmitting}
+            />
+          </View>
+        ) : (
+          <>
+            <ScrollView
+              contentContainerStyle={[
+                styles.content,
+                step !== "preparing" && styles.contentWithFooter,
               ]}
+              showsVerticalScrollIndicator={false}
             >
-              <Ionicons
-                name="arrow-back"
-                size={22}
-                color={theme.colors.text.primary}
-              />
-            </Pressable>
-          </View>
-          <View style={styles.stepViewport}>
-            <Animated.View
-              style={[
-                styles.stepAnimatedContainer,
-                styles.stepLayerCurrent,
-                buildStepAnimatedStyle(),
-              ]}
-            >
-              {renderStepContent(step)}
-            </Animated.View>
-          </View>
-        </ScrollView>
+              <View style={styles.headerRow}>
+                <Pressable
+                  accessibilityLabel="이전"
+                  onPress={handleBack}
+                  style={({ pressed }) => [
+                    styles.backButton,
+                    pressed && styles.backButtonPressed,
+                  ]}
+                >
+                  <Ionicons
+                    name="arrow-back"
+                    size={22}
+                    color={theme.colors.text.primary}
+                  />
+                </Pressable>
+              </View>
+              <View style={styles.stepViewport}>
+                <Animated.View
+                  style={[
+                    styles.stepAnimatedContainer,
+                    styles.stepLayerCurrent,
+                    buildStepAnimatedStyle(),
+                  ]}
+                >
+                  {renderStepContent(step)}
+                </Animated.View>
+              </View>
+            </ScrollView>
 
-        {step !== "preparing" ? (
-          <View style={styles.footerCta}>
-            {step === "level" ? (
-              <Pressable
-                accessibilityLabel="학습 수준 다음 단계"
-                style={[
-                  styles.primaryButton,
-                  !level && styles.primaryButtonDisabled,
-                ]}
-                onPress={() => {
-                  if (!level) return;
-                  // Skip the goal step (gated off with speaking).
-                  transitionToStep("details");
-                }}
-                disabled={!level}
-              >
-                <Text style={styles.primaryButtonText}>다음</Text>
-              </Pressable>
-            ) : null}
+            {step !== "preparing" ? (
+              <View style={styles.footerCta}>
+                {step === "level" ? (
+                  <Pressable
+                    accessibilityLabel="학습 수준 다음 단계"
+                    style={[
+                      styles.primaryButton,
+                      !level && styles.primaryButtonDisabled,
+                    ]}
+                    onPress={() => {
+                      if (!level) return;
+                      // Skip the goal step (gated off with speaking).
+                      transitionToStep("details");
+                    }}
+                    disabled={!level}
+                  >
+                    <Text style={styles.primaryButtonText}>다음</Text>
+                  </Pressable>
+                ) : null}
 
-            {step === "goal" ? (
-              <Pressable
-                accessibilityLabel="학습 목표 다음 단계"
-                style={[
-                  styles.primaryButton,
-                  !goalMode && styles.primaryButtonDisabled,
-                ]}
-                onPress={() => {
-                  if (!goalMode) return;
-                  transitionToStep("details");
-                }}
-                disabled={!goalMode}
-              >
-                <Text style={styles.primaryButtonText}>다음</Text>
-              </Pressable>
-            ) : null}
+                {step === "goal" ? (
+                  <Pressable
+                    accessibilityLabel="학습 목표 다음 단계"
+                    style={[
+                      styles.primaryButton,
+                      !goalMode && styles.primaryButtonDisabled,
+                    ]}
+                    onPress={() => {
+                      if (!goalMode) return;
+                      transitionToStep("details");
+                    }}
+                    disabled={!goalMode}
+                  >
+                    <Text style={styles.primaryButtonText}>다음</Text>
+                  </Pressable>
+                ) : null}
 
-            {step === "details" ? (
-              <Pressable
-                accessibilityLabel="온보딩 완료하기"
-                style={[
-                  styles.primaryButton,
-                  (!canSubmit || isSaving) && styles.primaryButtonDisabled,
-                ]}
-                onPress={handleComplete}
-                disabled={!canSubmit || isSaving}
-              >
-                <Text style={styles.primaryButtonText}>
-                  {isEditMode ? "저장하기" : "저장하기"}
-                </Text>
-              </Pressable>
+                {step === "details" ? (
+                  <Pressable
+                    accessibilityLabel="온보딩 완료하기"
+                    style={[
+                      styles.primaryButton,
+                      (!canSubmit || isSaving) && styles.primaryButtonDisabled,
+                    ]}
+                    onPress={handleComplete}
+                    disabled={!canSubmit || isSaving}
+                  >
+                    <Text style={styles.primaryButtonText}>
+                      {isEditMode ? "저장하기" : "저장하기"}
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </View>
             ) : null}
-          </View>
-        ) : null}
+          </>
+        )}
       </View>
     </SafeAreaView>
   );

--- a/apps/mobile/src/__tests__/onboarding-flow.test.tsx
+++ b/apps/mobile/src/__tests__/onboarding-flow.test.tsx
@@ -4,6 +4,7 @@ import { fireEvent, render, waitFor } from "@testing-library/react-native";
 const mockReplace = jest.fn();
 const mockUpdateLearningProfile = jest.fn();
 const mockTrackEvent = jest.fn();
+const mockSubmitVocab = jest.fn();
 let mockParams: { edit?: string } = {};
 let mockLearningProfile: any = null;
 
@@ -27,6 +28,12 @@ jest.mock("../../src/lib/analytics", () => ({
   trackEvent: (...args: unknown[]) => mockTrackEvent(...args),
 }));
 
+// premium-api pulls in @/lib/supabase (throws at load without env). Mock it so
+// onboarding can import submitVocabAssessment in tests.
+jest.mock("../../src/lib/premium-api", () => ({
+  submitVocabAssessment: (...args: unknown[]) => mockSubmitVocab(...args),
+}));
+
 describe("OnboardingScreen", () => {
   const OnboardingScreen = require("../../app/onboarding").default;
 
@@ -35,8 +42,34 @@ describe("OnboardingScreen", () => {
     mockUpdateLearningProfile.mockReset();
     mockUpdateLearningProfile.mockResolvedValue({});
     mockTrackEvent.mockClear();
+    mockSubmitVocab.mockReset();
+    mockSubmitVocab.mockResolvedValue({
+      estimatedBand: "conversation",
+      estimatedLevel: "B1",
+      seedCount: 12,
+    });
     mockParams = {};
     mockLearningProfile = null;
+  });
+
+  it("measures the band via the vocab test then advances to details", async () => {
+    const { getByText, queryByText } = render(<OnboardingScreen />);
+
+    // Vocab test is the first step. Page through to the end and submit.
+    for (let i = 0; i < 12; i += 1) {
+      const next = queryByText("다음");
+      if (!next) break;
+      fireEvent.press(next);
+    }
+    fireEvent.press(getByText("결과 확인"));
+
+    await waitFor(() => {
+      expect(mockSubmitVocab).toHaveBeenCalled();
+      // Advanced to the details step after the server returns the band.
+      expect(
+        getByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?"),
+      ).toBeTruthy();
+    });
   });
 
   it("completes onboarding and saves the learning profile with expression as the forced goal", async () => {
@@ -45,6 +78,8 @@ describe("OnboardingScreen", () => {
     // goal_mode is always "expression" at submit time.
     const { getByText, getByLabelText } = render(<OnboardingScreen />);
 
+    // Skip the vocab test to reach the manual level picker (fallback path).
+    fireEvent.press(getByText("건너뛰고 직접 선택할게요"));
     fireEvent.press(getByText("일상 회화는 가능해요"));
     fireEvent.press(getByLabelText("학습 수준 다음 단계"));
     fireEvent.press(getByText("학교/업무"));
@@ -122,6 +157,7 @@ describe("OnboardingScreen", () => {
       <OnboardingScreen />,
     );
 
+    fireEvent.press(getByText("건너뛰고 직접 선택할게요"));
     fireEvent.press(getByText("일상 회화는 가능해요"));
     fireEvent.press(getByLabelText("학습 수준 다음 단계"));
     fireEvent.press(getByText("학교/업무"));

--- a/apps/mobile/src/components/onboarding/VocabAssessment.tsx
+++ b/apps/mobile/src/components/onboarding/VocabAssessment.tsx
@@ -1,0 +1,231 @@
+import React, { useMemo, useRef, useState } from "react";
+import {
+  ActivityIndicator,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from "react-native";
+import { buildAssessmentItems } from "@inputenglish/shared";
+import type { AssessmentItem } from "@inputenglish/shared";
+import { useTheme, createThemedStyles } from "@/components/ui";
+import type { VocabAnswer } from "@/lib/premium-api";
+
+// @MX:NOTE: Onboarding Yes/No vocab-size test (SPEC-INPUT-003 REQ-VOCAB-A/I).
+// Items are sampled client-side from the shared frequency list; the SERVER is
+// authoritative — it re-derives isReal/band from the same list on submit
+// (contract C5.4). We only collect { token, known } and never send band/isReal.
+
+const WORDS_PER_BAND = 10; // 4 bands → ~40 real words
+const PSEUDOWORD_COUNT = 10; // false-positive correction items
+const WORDS_PER_PAGE = 12;
+
+function chunk<T>(arr: T[], size: number): T[][] {
+  const pages: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    pages.push(arr.slice(i, i + size));
+  }
+  return pages;
+}
+
+interface VocabAssessmentProps {
+  onComplete: (answers: VocabAnswer[]) => void;
+  onSkip: () => void;
+  submitting?: boolean;
+  /** Fixed seed for deterministic item sampling (tests). */
+  seed?: number;
+}
+
+export function VocabAssessment({
+  onComplete,
+  onSkip,
+  submitting = false,
+  seed,
+}: VocabAssessmentProps) {
+  const theme = useTheme();
+  const styles = getStyles(theme);
+
+  // Sample once per mount. The server re-validates, so a random seed is safe.
+  const seedRef = useRef<number>(
+    seed ?? Math.floor(Math.random() * 1_000_000_000),
+  );
+  const items = useMemo<AssessmentItem[]>(
+    () =>
+      buildAssessmentItems({
+        wordsPerBand: WORDS_PER_BAND,
+        pseudowordCount: PSEUDOWORD_COUNT,
+        seed: seedRef.current,
+      }),
+    [],
+  );
+  const pages = useMemo(() => chunk(items, WORDS_PER_PAGE), [items]);
+
+  const [pageIndex, setPageIndex] = useState(0);
+  // token -> known (default: not known). User taps words they recognize.
+  const [known, setKnown] = useState<Record<string, boolean>>({});
+
+  const toggle = (token: string) =>
+    setKnown((prev) => ({ ...prev, [token]: !prev[token] }));
+
+  const isLastPage = pageIndex === pages.length - 1;
+  const progress = (pageIndex + 1) / pages.length;
+
+  const handleNext = () => {
+    if (submitting) return;
+    if (!isLastPage) {
+      setPageIndex((p) => p + 1);
+      return;
+    }
+    const answers: VocabAnswer[] = items.map((item) => ({
+      token: item.token,
+      known: Boolean(known[item.token]),
+    }));
+    onComplete(answers);
+  };
+
+  const currentPage = pages[pageIndex] ?? [];
+
+  return (
+    <View style={styles.root}>
+      <View style={styles.progressTrack}>
+        <View style={[styles.progressFill, { width: `${progress * 100}%` }]} />
+      </View>
+
+      <Text style={styles.title}>아는 단어를 모두 골라주세요</Text>
+      <Text style={styles.subtitle}>
+        뜻이 떠오르는 단어만 탭하세요. 모르면 그냥 두면 돼요. 정확한 추천을 위해
+        실력을 잰답니다.
+      </Text>
+
+      <ScrollView
+        style={styles.wordsScroll}
+        contentContainerStyle={styles.wordGrid}
+        showsVerticalScrollIndicator={false}
+      >
+        {currentPage.map((item) => {
+          const isKnown = Boolean(known[item.token]);
+          return (
+            <Pressable
+              key={item.token}
+              accessibilityLabel={`단어 ${item.token}`}
+              accessibilityState={{ selected: isKnown }}
+              onPress={() => toggle(item.token)}
+              style={[styles.wordChip, isKnown && styles.wordChipKnown]}
+            >
+              <Text style={[styles.wordText, isKnown && styles.wordTextKnown]}>
+                {item.token}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+
+      <View style={styles.footer}>
+        <Pressable
+          accessibilityLabel={isLastPage ? "어휘 평가 제출" : "다음 단어 묶음"}
+          onPress={handleNext}
+          disabled={submitting}
+          style={[styles.primaryButton, submitting && styles.buttonDisabled]}
+        >
+          {submitting ? (
+            <ActivityIndicator color={theme.colors.text.inverse} />
+          ) : (
+            <Text style={styles.primaryButtonText}>
+              {isLastPage ? "결과 확인" : "다음"}
+            </Text>
+          )}
+        </Pressable>
+
+        <Pressable
+          accessibilityLabel="테스트 건너뛰고 직접 선택"
+          onPress={onSkip}
+          disabled={submitting}
+          style={styles.skipButton}
+        >
+          <Text style={styles.skipText}>건너뛰고 직접 선택할게요</Text>
+        </Pressable>
+      </View>
+    </View>
+  );
+}
+
+const getStyles = createThemedStyles((theme) => ({
+  root: {
+    flex: 1,
+  },
+  progressTrack: {
+    height: 4,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.surface.muted,
+    overflow: "hidden" as const,
+    marginBottom: theme.spacing[6],
+  },
+  progressFill: {
+    height: 4,
+    borderRadius: theme.radius.full,
+    backgroundColor: theme.colors.action.primary,
+  },
+  title: {
+    ...theme.typography.title,
+    color: theme.colors.text.primary,
+    marginBottom: theme.spacing[2],
+  },
+  subtitle: {
+    ...theme.typography.body,
+    color: theme.colors.text.secondary,
+    marginBottom: theme.spacing[4],
+  },
+  wordsScroll: {
+    flex: 1,
+  },
+  wordGrid: {
+    flexDirection: "row" as const,
+    flexWrap: "wrap" as const,
+    gap: theme.spacing[2],
+    paddingBottom: theme.spacing[4],
+  },
+  wordChip: {
+    borderRadius: theme.radius.full,
+    borderWidth: 1,
+    borderColor: theme.colors.border.default,
+    backgroundColor: theme.colors.surface.muted,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: 10,
+  },
+  wordChipKnown: {
+    borderColor: theme.colors.action.primary,
+    backgroundColor: theme.colors.action.primary,
+  },
+  wordText: {
+    ...theme.typography.bodyStrong,
+    color: theme.colors.text.primary,
+  },
+  wordTextKnown: {
+    color: theme.colors.text.inverse,
+  },
+  footer: {
+    gap: theme.spacing[2],
+    paddingTop: theme.spacing[4],
+  },
+  primaryButton: {
+    backgroundColor: theme.colors.action.primary,
+    borderRadius: theme.radius.full,
+    paddingVertical: theme.spacing[4],
+    alignItems: "center" as const,
+  },
+  buttonDisabled: {
+    opacity: 0.5,
+  },
+  primaryButtonText: {
+    ...theme.typography.button,
+    color: theme.colors.text.inverse,
+  },
+  skipButton: {
+    alignItems: "center" as const,
+    paddingVertical: theme.spacing[2],
+  },
+  skipText: {
+    ...theme.typography.label,
+    color: theme.colors.text.secondary,
+  },
+}));

--- a/apps/mobile/src/lib/analytics.ts
+++ b/apps/mobile/src/lib/analytics.ts
@@ -14,6 +14,8 @@ export type AnalyticsEventName =
   | "onboarding_step_viewed"
   | "onboarding_level_selected"
   | "onboarding_goal_selected"
+  | "onboarding_vocab_assessed"
+  | "onboarding_vocab_skipped"
   | "onboarding_complete"
   | "tab_changed"
   | "daily_input_impression"

--- a/apps/mobile/src/lib/premium-api.ts
+++ b/apps/mobile/src/lib/premium-api.ts
@@ -4,6 +4,7 @@ import type {
   PremiumSession,
   ReadingPiece,
   VideoSegment,
+  VocabBand,
 } from "@inputenglish/shared";
 import { premiumSessionFixture } from "@/fixtures/premium-session";
 import { ciSessionFixture } from "@/fixtures/ci-session";
@@ -270,4 +271,53 @@ export async function askHighlightQuestion(
   }
 
   return response.json() as Promise<QuestionResponse>;
+}
+
+// --- Vocab assessment (SPEC-INPUT-003 REQ-VOCAB-P) ---
+
+export interface VocabAnswer {
+  token: string;
+  known: boolean;
+}
+
+export interface VocabAssessmentResult {
+  estimatedBand: VocabBand;
+  estimatedLevel: string;
+  seedCount: number;
+}
+
+// Submit the onboarding Yes/No vocab test. The server is authoritative: it
+// re-derives isReal/band from the frequency list, scores, and persists
+// user_vocab_profiles + seed known_words. We only send { token, known }.
+export async function submitVocabAssessment(
+  answers: VocabAnswer[],
+): Promise<VocabAssessmentResult> {
+  const webApiUrl = getWebApiUrl();
+  if (shouldForceFixtureMode(webApiUrl)) {
+    return {
+      estimatedBand: "conversation",
+      estimatedLevel: "B1",
+      seedCount: answers.filter((a) => a.known).length,
+    };
+  }
+  if (!webApiUrl) {
+    throw new PremiumApiConfigurationError();
+  }
+
+  const response = await fetch(`${webApiUrl}/api/premium/vocab-assessment`, {
+    method: "POST",
+    headers: await getAuthHeaders(),
+    body: JSON.stringify({ answers }),
+  });
+
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => ({}))) as {
+      error?: string;
+    };
+    throw new Error(
+      payload.error ?? `어휘 평가 제출에 실패했어요. (${response.status})`,
+    );
+  }
+
+  return response.json() as Promise<VocabAssessmentResult>;
 }


### PR DESCRIPTION
## Mobile onboarding — Yes/No vocab test (skeleton + flow)

The missing consumer for the SPEC-INPUT-003 backend: instead of a self-reported 4-choice level, onboarding now **measures** the user's vocabulary band, which drives all content↔level matching (`resolveUserBand`, i+1 reading gate).

**Skeleton + flow only** — structure, navigation, and data contract are accurate; visual design is intentionally minimal pending polish.

### Flow
```
[vocab test]  ← primary first step (fresh onboarding)
   │ tap known words across paged screens → "결과 확인"
   ▼
POST /api/premium/vocab-assessment  → server scores + persists
   │   user_vocab_profiles + seed known_words, returns estimatedBand
   ▼
[details] (interests) → [preparing] (save profile, level_band = estimatedBand)

skip / failure ──▶ [level] manual 4-choice fallback (abandonment-safe, I-W1)
edit mode ────────▶ starts at [level] (no re-test on a profile edit)
```

### Changes
- `VocabAssessment` component — samples items client-side via shared `buildAssessmentItems`, pages word chips (tap = known), submits `{ token, known }[]`. Server is authoritative on isReal/band (contract C5.4); client never sends them.
- `premium-api.submitVocabAssessment` → POST with fixture-mode stub.
- `onboarding.tsx` — `vocab` as primary step; manual `level` demoted to skip/fallback.
- `analytics` — `onboarding_vocab_assessed` / `_skipped`.

### Verified
Mobile `jest`: 42 suites / 271 tests pass (incl. a new vocab-flow test + updated fallback tests). Mobile `tsc --noEmit`: 0.

### Follow-ups (not in this skeleton)
- Visual design pass (word chip grid, progress, result reveal).
- A dedicated GET items endpoint if we want server-driven sampling (currently client-side via shared, which is contract-safe).
- Intro/explainer screen before the test.

🗿 MoAI <email@mo.ai.kr>