### PR TITLE
fix(mobile): vocab onboarding back button paginates back

### DIFF
--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -1114,25 +1114,10 @@ export default function OnboardingScreen() {
       <View style={styles.screen}>
         {step === "vocab" ? (
           <View style={styles.vocabContainer}>
-            <View style={styles.headerRow}>
-              <Pressable
-                accessibilityLabel="이전"
-                onPress={handleBack}
-                style={({ pressed }) => [
-                  styles.backButton,
-                  pressed && styles.backButtonPressed,
-                ]}
-              >
-                <Ionicons
-                  name="arrow-back"
-                  size={22}
-                  color={theme.colors.text.primary}
-                />
-              </Pressable>
-            </View>
             <VocabAssessment
               onComplete={handleVocabComplete}
               onSkip={handleVocabSkip}
+              onBack={handleBack}
               submitting={vocabSubmitting}
             />
           </View>

--- a/apps/mobile/src/__tests__/onboarding-flow.test.tsx
+++ b/apps/mobile/src/__tests__/onboarding-flow.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { fireEvent, render, waitFor } from "@testing-library/react-native";
 
 const mockReplace = jest.fn();
+const mockBack = jest.fn();
 const mockUpdateLearningProfile = jest.fn();
 const mockTrackEvent = jest.fn();
 const mockSubmitVocab = jest.fn();
@@ -11,6 +12,7 @@ let mockLearningProfile: any = null;
 jest.mock("expo-router", () => ({
   router: {
     replace: (...args: unknown[]) => mockReplace(...args),
+    back: (...args: unknown[]) => mockBack(...args),
   },
   useLocalSearchParams: jest.fn(() => mockParams),
 }));
@@ -42,6 +44,7 @@ describe("OnboardingScreen", () => {
     mockUpdateLearningProfile.mockReset();
     mockUpdateLearningProfile.mockResolvedValue({});
     mockTrackEvent.mockClear();
+    mockBack.mockClear();
     mockSubmitVocab.mockReset();
     mockSubmitVocab.mockResolvedValue({
       estimatedBand: "conversation",
@@ -70,6 +73,21 @@ describe("OnboardingScreen", () => {
         getByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?"),
       ).toBeTruthy();
     });
+  });
+
+  it("vocab back goes one page within the test, and exits from the first page", () => {
+    const { getByText, getByLabelText } = render(<OnboardingScreen />);
+
+    // First page: back exits the test (router.back).
+    fireEvent.press(getByLabelText("이전"));
+    expect(mockBack).toHaveBeenCalledTimes(1);
+
+    mockBack.mockClear();
+
+    // Advance a page, then back stays inside the test (no router.back).
+    fireEvent.press(getByText("다음"));
+    fireEvent.press(getByLabelText("이전"));
+    expect(mockBack).not.toHaveBeenCalled();
   });
 
   it("completes onboarding and saves the learning profile with expression as the forced goal", async () => {

--- a/apps/mobile/src/components/onboarding/VocabAssessment.tsx
+++ b/apps/mobile/src/components/onboarding/VocabAssessment.tsx
@@ -6,6 +6,7 @@ import {
   Text,
   View,
 } from "react-native";
+import { Ionicons } from "@expo/vector-icons";
 import { buildAssessmentItems } from "@inputenglish/shared";
 import type { AssessmentItem } from "@inputenglish/shared";
 import { useTheme, createThemedStyles } from "@/components/ui";
@@ -31,6 +32,8 @@ function chunk<T>(arr: T[], size: number): T[][] {
 interface VocabAssessmentProps {
   onComplete: (answers: VocabAnswer[]) => void;
   onSkip: () => void;
+  /** Called when back is pressed on the first page (exit the test). */
+  onBack: () => void;
   submitting?: boolean;
   /** Fixed seed for deterministic item sampling (tests). */
   seed?: number;
@@ -39,6 +42,7 @@ interface VocabAssessmentProps {
 export function VocabAssessment({
   onComplete,
   onSkip,
+  onBack,
   submitting = false,
   seed,
 }: VocabAssessmentProps) {
@@ -83,10 +87,37 @@ export function VocabAssessment({
     onComplete(answers);
   };
 
+  // Back goes one page within the test; from the first page it exits via onBack.
+  const handleBackPress = () => {
+    if (submitting) return;
+    if (pageIndex > 0) {
+      setPageIndex((p) => p - 1);
+      return;
+    }
+    onBack();
+  };
+
   const currentPage = pages[pageIndex] ?? [];
 
   return (
     <View style={styles.root}>
+      <View style={styles.headerRow}>
+        <Pressable
+          accessibilityLabel="이전"
+          onPress={handleBackPress}
+          disabled={submitting}
+          style={({ pressed }) => [
+            styles.backButton,
+            pressed && styles.backButtonPressed,
+          ]}
+        >
+          <Ionicons
+            name="arrow-back"
+            size={22}
+            color={theme.colors.text.primary}
+          />
+        </Pressable>
+      </View>
       <View style={styles.progressTrack}>
         <View style={[styles.progressFill, { width: `${progress * 100}%` }]} />
       </View>
@@ -152,6 +183,21 @@ export function VocabAssessment({
 const getStyles = createThemedStyles((theme) => ({
   root: {
     flex: 1,
+  },
+  headerRow: {
+    alignItems: "flex-start" as const,
+    marginBottom: theme.spacing[4],
+  },
+  backButton: {
+    width: 40,
+    height: 40,
+    borderRadius: theme.radius.full,
+    alignItems: "center" as const,
+    justifyContent: "center" as const,
+    marginLeft: -theme.spacing[1],
+  },
+  backButtonPressed: {
+    opacity: 0.7,
   },
   progressTrack: {
     height: 4,


### PR DESCRIPTION
## Vocab onboarding back button fix

On the vocab test step, the back button only called `router.back()` — which no-ops after signup (onboarding is entered via `router.replace`), so back did nothing inside the multi-page Yes/No test.

**Fix:** VocabAssessment now owns its back button. It goes to the **previous page** when `pageIndex > 0`, and only calls the parent `onBack` (router.back) from the **first page**. The duplicate onboarding-header back button on the vocab step is removed.

Tests: added a back-navigation test (first-page back exits via router.back; mid-test back paginates without exiting). Mobile jest 272 pass, tsc 0.