### PR TITLE
feat(mobile): vocab onboarding polish + v1.3 topic/format interests

### DIFF
--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -6,13 +6,10 @@ import React, {
   useState,
 } from "react";
 import { Ionicons } from "@expo/vector-icons";
-import { LinearGradient } from "expo-linear-gradient";
 import {
   ActivityIndicator,
   Animated,
   Easing,
-  ImageSourcePropType,
-  ImageBackground,
   LayoutAnimation,
   Platform,
   Pressable,
@@ -25,35 +22,16 @@ import {
   View,
 } from "react-native";
 import { router, useLocalSearchParams } from "expo-router";
-import {
-  GENRES,
-  SPEAKING_SITUATIONS,
-  SPEAKING_SITUATION_LABELS,
-} from "@inputenglish/shared";
-import type {
-  Genre,
-  LearningGoalMode,
-  LearningLevelBand,
-  SpeakingSituation,
-} from "@inputenglish/shared";
-import { GENRE_LABELS } from "@/lib/professional-labels";
+import type { LearningLevelBand } from "@inputenglish/shared";
 import { useAuth } from "@/contexts/AuthContext";
 import { trackEvent } from "@/lib/analytics";
-import { inferPremiumPreferredSourceTypes } from "@/lib/premium-interest-clusters";
 import { useTheme, createThemedStyles } from "@/components/ui";
-import { mediaOverlay } from "@inputenglish/design-tokens";
 import { VocabAssessment } from "@/components/onboarding/VocabAssessment";
 import { submitVocabAssessment } from "@/lib/premium-api";
 import type { VocabAnswer } from "@/lib/premium-api";
 import { safeSelectionAsync, safeImpactLight } from "@/lib/safeHaptic";
 
-type OnboardingStep =
-  | "vocab"
-  | "level"
-  | "goal"
-  | "topics"
-  | "formats"
-  | "preparing";
+type OnboardingStep = "vocab" | "level" | "topics" | "formats" | "preparing";
 
 // @MX:NOTE: Interest questions are aligned to the v1.3 CI content model
 //   (reading pool = band × format × topic). TOPIC values match the reading
@@ -84,13 +62,8 @@ const TOPIC_TAG_PREFIX = "topic:";
 const FORMAT_TAG_PREFIX = "format:";
 // @MX:NOTE: "vocab" is the primary first step — a Yes/No vocab-size test
 //           (SPEC-INPUT-003) that measures the user's band instead of the
-//           self-reported 4-choice. "level" is kept as an off-sequence
-//           fallback reached by skipping the test (abandonment, I-W1).
-// @MX:NOTE: Speaking/pronunciation is feature-gated on main until the
-//           Azure + ffmpeg pipeline on feature/speaking-stability is
-//           stable. The "goal" step is dropped because "expression" is
-//           the only selectable goal_mode right now; re-insert it here
-//           when speaking returns.
+//           self-reported 4-choice. "level" is an off-sequence fallback used
+//           only on vocab-test failure or in edit mode (abandonment, I-W1).
 const STEP_SEQUENCE: OnboardingStep[] = [
   "vocab",
   "topics",
@@ -105,74 +78,7 @@ const LEVEL_OPTIONS: Array<{ value: LearningLevelBand; label: string }> = [
   { value: "professional", label: "영어로 업무 소통이나 논의까지 가능해요" },
 ];
 
-const PRONUNCIATION_PEOPLE = [
-  {
-    name: "Michelle Obama",
-    trait: "차분하고 또렷한 리더형 리듬",
-    imageSource: require("../assets/images/speakers/person_1.png"),
-  },
-  {
-    name: "Oprah",
-    trait: "따뜻하고 밀도 있는 저음 톤",
-    imageSource: require("../assets/images/speakers/person_2.png"),
-  },
-  {
-    name: "Taylor Swift",
-    trait: "부드럽고 선명한 미국식 딕션",
-    imageSource: require("../assets/images/speakers/person_3.png"),
-  },
-  {
-    name: "Zendaya",
-    trait: "가볍고 세련된 대화체 억양",
-    imageSource: require("../assets/images/speakers/person_4.png"),
-  },
-  {
-    name: "Emma Watson",
-    trait: "정갈한 영국식 발음과 호흡",
-    imageSource: require("../assets/images/speakers/person_5.png"),
-  },
-  {
-    name: "Jennie",
-    trait: "짧고 감각적인 글로벌 톤",
-    imageSource: require("../assets/images/speakers/person_6.png"),
-  },
-  {
-    name: "Ryan Reynolds",
-    trait: "위트 있게 튀는 북미식 리듬",
-    imageSource: require("../assets/images/speakers/person_7.png"),
-  },
-  {
-    name: "Matt Damon",
-    trait: "담백하고 안정적인 표준 억양",
-    imageSource: require("../assets/images/speakers/person_8.png"),
-  },
-  {
-    name: "Jensen Huang",
-    trait: "명확하고 에너지 있는 발표 톤",
-    imageSource: require("../assets/images/speakers/person_9.png"),
-  },
-  {
-    name: "Simon Sinek",
-    trait: "단단하고 설득력 있는 강연 호흡",
-    imageSource: require("../assets/images/speakers/person_10.png"),
-  },
-  {
-    name: "Conan O'Brien",
-    trait: "리듬감 있고 장난기 있는 억양",
-    imageSource: require("../assets/images/speakers/person_11.png"),
-  },
-  {
-    name: "Barack Obama",
-    trait: "여유롭고 묵직한 연설형 억양",
-    imageSource: require("../assets/images/speakers/person_12.png"),
-  },
-] as const;
-
 const IS_TEST_ENV = process.env.NODE_ENV === "test";
-
-function dedupe(values: string[]) {
-  return [...new Set(values)];
-}
 
 const getOptionButtonStyles = createThemedStyles((theme) => ({
   optionPressable: {
@@ -345,256 +251,6 @@ function MultiSelectRow({
   );
 }
 
-const getChoiceChipStyles = createThemedStyles((theme) => ({
-  chipPressable: {
-    alignSelf: "flex-start" as const,
-  },
-  chip: {
-    borderRadius: theme.radius.full,
-    borderWidth: 1,
-    borderColor: theme.colors.border.default,
-    backgroundColor: theme.colors.surface.muted,
-    paddingHorizontal: theme.spacing[4],
-    paddingVertical: 10,
-  },
-  chipPressed: {
-    opacity: 0.92,
-  },
-  chipText: {
-    ...theme.typography.label,
-    color: theme.colors.text.primary,
-  },
-}));
-
-function ChoiceChip({
-  label,
-  selected,
-  onPress,
-}: {
-  label: string;
-  selected: boolean;
-  onPress: () => void;
-}) {
-  const theme = useTheme();
-  const styles = getChoiceChipStyles(theme);
-  const selectionAnim = useRef(new Animated.Value(selected ? 1 : 0)).current;
-
-  useEffect(() => {
-    if (IS_TEST_ENV) {
-      selectionAnim.setValue(selected ? 1 : 0);
-      return;
-    }
-
-    Animated.timing(selectionAnim, {
-      toValue: selected ? 1 : 0,
-      duration: 180,
-      easing: Easing.out(Easing.quad),
-      useNativeDriver: false,
-    }).start();
-  }, [selected, selectionAnim]);
-
-  return (
-    <Pressable
-      onPress={() => {
-        safeSelectionAsync();
-        onPress();
-      }}
-      style={({ pressed }) => [
-        styles.chipPressable,
-        pressed && styles.chipPressed,
-      ]}
-    >
-      <Animated.View
-        style={[
-          styles.chip,
-          {
-            backgroundColor: selectionAnim.interpolate({
-              inputRange: [0, 1],
-              outputRange: [
-                theme.colors.surface.muted,
-                theme.colors.action.primary,
-              ],
-            }),
-            borderColor: selectionAnim.interpolate({
-              inputRange: [0, 1],
-              outputRange: [
-                theme.colors.border.default,
-                theme.colors.action.primary,
-              ],
-            }),
-          },
-        ]}
-      >
-        <Animated.Text
-          style={[
-            styles.chipText,
-            {
-              color: selectionAnim.interpolate({
-                inputRange: [0, 1],
-                outputRange: [
-                  theme.colors.text.primary,
-                  theme.colors.text.inverse,
-                ],
-              }),
-            },
-          ]}
-        >
-          {label}
-        </Animated.Text>
-      </Animated.View>
-    </Pressable>
-  );
-}
-
-const getPersonCardStyles = createThemedStyles((theme) => ({
-  personCardPressable: {
-    width: "48.5%" as const,
-  },
-  personCard: {
-    aspectRatio: 1,
-    borderRadius: theme.radius.lg,
-    overflow: "hidden" as const,
-    borderWidth: 2,
-    backgroundColor: theme.colors.surface.muted,
-  },
-  personCardPressed: {
-    opacity: 0.92,
-  },
-  personImage: {
-    flex: 1,
-  },
-  // borderRadius matches card minus border width to avoid inner corner bleed
-  personImageInner: {
-    borderRadius: theme.radius.lg - 2,
-  },
-  personGradient: {
-    flex: 1,
-    justifyContent: "space-between" as const,
-    padding: theme.spacing[2],
-  },
-  personCardBadge: {
-    alignSelf: "flex-end" as const,
-    width: 24,
-    height: 24,
-    borderRadius: theme.radius.lg,
-    backgroundColor: mediaOverlay.badge,
-    alignItems: "center" as const,
-    justifyContent: "center" as const,
-  },
-  personCopy: {
-    gap: 2,
-  },
-  personName: {
-    ...theme.typography.bodyStrong,
-    color: theme.colors.text.inverse,
-  },
-  personTrait: {
-    fontSize: 11,
-    lineHeight: 16,
-    color: mediaOverlay.onImageText,
-  },
-}));
-
-function PronunciationPersonCard({
-  name,
-  trait,
-  imageSource,
-  selected,
-  onPress,
-}: {
-  name: string;
-  trait: string;
-  imageSource: ImageSourcePropType;
-  selected: boolean;
-  onPress: () => void;
-}) {
-  const theme = useTheme();
-  const styles = getPersonCardStyles(theme);
-  const selectionAnim = useRef(new Animated.Value(selected ? 1 : 0)).current;
-
-  useEffect(() => {
-    if (IS_TEST_ENV) {
-      selectionAnim.setValue(selected ? 1 : 0);
-      return;
-    }
-
-    Animated.timing(selectionAnim, {
-      toValue: selected ? 1 : 0,
-      duration: 180,
-      easing: Easing.out(Easing.quad),
-      useNativeDriver: false,
-    }).start();
-  }, [selected, selectionAnim]);
-
-  return (
-    <Pressable
-      onPress={() => {
-        safeSelectionAsync();
-        onPress();
-      }}
-      style={({ pressed }) => [
-        styles.personCardPressable,
-        pressed && styles.personCardPressed,
-      ]}
-    >
-      <Animated.View
-        style={[
-          styles.personCard,
-          {
-            borderColor: selectionAnim.interpolate({
-              inputRange: [0, 1],
-              outputRange: [
-                theme.colors.border.default,
-                theme.colors.action.primary,
-              ],
-            }),
-          },
-        ]}
-      >
-        <ImageBackground
-          source={imageSource}
-          style={styles.personImage}
-          imageStyle={styles.personImageInner}
-        >
-          <LinearGradient
-            colors={[
-              mediaOverlay.gradientTop,
-              mediaOverlay.gradientMid,
-              mediaOverlay.gradientBottom,
-            ]}
-            locations={[0, 0.45, 1]}
-            style={styles.personGradient}
-          >
-            <Animated.View
-              style={[
-                styles.personCardBadge,
-                {
-                  opacity: selectionAnim.interpolate({
-                    inputRange: [0, 1],
-                    outputRange: [0, 1],
-                  }),
-                },
-              ]}
-            >
-              <Ionicons
-                name="checkmark"
-                size={14}
-                color={theme.colors.text.inverse}
-              />
-            </Animated.View>
-            <View style={styles.personCopy}>
-              <Text style={styles.personName}>{name}</Text>
-              <Text style={styles.personTrait} numberOfLines={1}>
-                {trait}
-              </Text>
-            </View>
-          </LinearGradient>
-        </ImageBackground>
-      </Animated.View>
-    </Pressable>
-  );
-}
-
 const getScreenStyles = createThemedStyles((theme) => ({
   container: {
     flex: 1,
@@ -674,32 +330,6 @@ const getScreenStyles = createThemedStyles((theme) => ({
     marginTop: theme.spacing[2],
     marginBottom: theme.spacing[8],
   },
-  modeRow: {
-    gap: theme.spacing[2],
-    marginBottom: theme.spacing[6],
-  },
-  focusSection: {
-    marginBottom: theme.spacing[8],
-  },
-  focusTitle: {
-    ...theme.typography.bodyStrong,
-    color: theme.colors.text.primary,
-    marginBottom: theme.spacing[2],
-  },
-  secondaryFocusTitle: {
-    marginTop: theme.spacing[6],
-  },
-  chipWrap: {
-    flexDirection: "row" as const,
-    flexWrap: "wrap" as const,
-    gap: theme.spacing[2],
-  },
-  personGrid: {
-    flexDirection: "row" as const,
-    flexWrap: "wrap" as const,
-    justifyContent: "space-between" as const,
-    gap: theme.spacing[2],
-  },
   primaryButton: {
     backgroundColor: theme.colors.action.primary,
     borderRadius: theme.radius.full,
@@ -741,12 +371,6 @@ export default function OnboardingScreen() {
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [level, setLevel] = useState<LearningLevelBand | null>(null);
   const [vocabSubmitting, setVocabSubmitting] = useState(false);
-  // @MX:NOTE: Pronunciation mode is feature-gated — default to expression
-  //           on main while speaking stability work continues on the
-  //           feature/speaking-stability branch.
-  const [goalMode, setGoalMode] = useState<LearningGoalMode | null>(
-    "expression",
-  );
   const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
   const [selectedFormats, setSelectedFormats] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
@@ -809,7 +433,6 @@ export default function OnboardingScreen() {
     hydratedProfileKeyRef.current = profileHydrationKey;
 
     setLevel(learningProfile.level_band);
-    setGoalMode("expression");
 
     // Hydrate v1.3 topic/format selections from focus_tags (prefixed).
     const tags = learningProfile.focus_tags ?? [];
@@ -942,11 +565,6 @@ export default function OnboardingScreen() {
       } else {
         transitionToStep("vocab");
       }
-      return;
-    }
-
-    if (step === "goal") {
-      transitionToStep("level");
       return;
     }
 

--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -47,7 +47,41 @@ import { submitVocabAssessment } from "@/lib/premium-api";
 import type { VocabAnswer } from "@/lib/premium-api";
 import { safeSelectionAsync, safeImpactLight } from "@/lib/safeHaptic";
 
-type OnboardingStep = "vocab" | "level" | "goal" | "details" | "preparing";
+type OnboardingStep =
+  | "vocab"
+  | "level"
+  | "goal"
+  | "topics"
+  | "formats"
+  | "preparing";
+
+// @MX:NOTE: Interest questions are aligned to the v1.3 CI content model
+//   (reading pool = band × format × topic). TOPIC values match the reading
+//   matrix + channel topics; FORMAT values match reading-generation formats.
+//   Selections persist into the learning profile's focus_tags (prefixed) for
+//   the v1.3 assembly wiring (follow-up).
+const TOPIC_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "science", label: "과학" },
+  { value: "technology", label: "테크 / IT" },
+  { value: "economics", label: "경제" },
+  { value: "health", label: "건강 / 웰빙" },
+  { value: "education", label: "교육 / 학습" },
+  { value: "culture", label: "문화 / 예술" },
+  { value: "history", label: "역사" },
+  { value: "climate", label: "환경 / 기후" },
+];
+
+const FORMAT_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "nonfiction", label: "정보 / 설명형" },
+  { value: "editorial", label: "시사 / 오피니언" },
+  { value: "dialogue", label: "대화 / 회화체" },
+  { value: "noir", label: "이야기 / 소설" },
+  { value: "business", label: "비즈니스 / 실무" },
+  { value: "economic", label: "경제 분석" },
+];
+
+const TOPIC_TAG_PREFIX = "topic:";
+const FORMAT_TAG_PREFIX = "format:";
 // @MX:NOTE: "vocab" is the primary first step — a Yes/No vocab-size test
 //           (SPEC-INPUT-003) that measures the user's band instead of the
 //           self-reported 4-choice. "level" is kept as an off-sequence
@@ -57,7 +91,12 @@ type OnboardingStep = "vocab" | "level" | "goal" | "details" | "preparing";
 //           stable. The "goal" step is dropped because "expression" is
 //           the only selectable goal_mode right now; re-insert it here
 //           when speaking returns.
-const STEP_SEQUENCE: OnboardingStep[] = ["vocab", "details", "preparing"];
+const STEP_SEQUENCE: OnboardingStep[] = [
+  "vocab",
+  "topics",
+  "formats",
+  "preparing",
+];
 
 const LEVEL_OPTIONS: Array<{ value: LearningLevelBand; label: string }> = [
   { value: "beginner", label: "거의 한 마디도 못해요" },
@@ -232,6 +271,76 @@ function OptionButton({
           {label}
         </Animated.Text>
       </Animated.View>
+    </Pressable>
+  );
+}
+
+const getMultiSelectRowStyles = createThemedStyles((theme) => ({
+  pressable: {
+    width: "100%" as const,
+  },
+  row: {
+    flexDirection: "row" as const,
+    alignItems: "center" as const,
+    justifyContent: "space-between" as const,
+    borderRadius: theme.radius.lg,
+    borderWidth: 1,
+    borderColor: theme.colors.border.default,
+    backgroundColor: theme.colors.surface.muted,
+    paddingHorizontal: theme.spacing[4],
+    paddingVertical: theme.spacing[4],
+  },
+  rowSelected: {
+    borderColor: theme.colors.action.primary,
+    backgroundColor: theme.colors.action.primary,
+  },
+  rowPressed: {
+    opacity: 0.92,
+  },
+  label: {
+    ...theme.typography.bodyStrong,
+    color: theme.colors.text.primary,
+  },
+  labelSelected: {
+    color: theme.colors.text.inverse,
+  },
+}));
+
+// Full-width, one-per-row multi-select button (replaces the wrap-chip layout).
+function MultiSelectRow({
+  label,
+  selected,
+  onPress,
+}: {
+  label: string;
+  selected: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const styles = getMultiSelectRowStyles(theme);
+  return (
+    <Pressable
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: selected }}
+      accessibilityLabel={label}
+      onPress={() => {
+        safeSelectionAsync();
+        onPress();
+      }}
+      style={({ pressed }) => [styles.pressable, pressed && styles.rowPressed]}
+    >
+      <View style={[styles.row, selected && styles.rowSelected]}>
+        <Text style={[styles.label, selected && styles.labelSelected]}>
+          {label}
+        </Text>
+        <Ionicons
+          name={selected ? "checkmark-circle" : "ellipse-outline"}
+          size={22}
+          color={
+            selected ? theme.colors.text.inverse : theme.colors.text.secondary
+          }
+        />
+      </View>
     </Pressable>
   );
 }
@@ -638,11 +747,8 @@ export default function OnboardingScreen() {
   const [goalMode, setGoalMode] = useState<LearningGoalMode | null>(
     "expression",
   );
-  const [focusTags, setFocusTags] = useState<string[]>([]);
-  const [expressionSituations, setExpressionSituations] = useState<string[]>(
-    [],
-  );
-  const [expressionTopics, setExpressionTopics] = useState<string[]>([]);
+  const [selectedTopics, setSelectedTopics] = useState<string[]>([]);
+  const [selectedFormats, setSelectedFormats] = useState<string[]>([]);
   const [isSaving, setIsSaving] = useState(false);
   const hydratedProfileKeyRef = useRef<string | null>(null);
   const stepTransition = useRef(new Animated.Value(1)).current;
@@ -703,73 +809,29 @@ export default function OnboardingScreen() {
     hydratedProfileKeyRef.current = profileHydrationKey;
 
     setLevel(learningProfile.level_band);
-    // @MX:NOTE: Coerce any legacy "pronunciation" profile into "expression"
-    //           while the speaking feature is gated off on main. The
-    //           pronunciation-specific focus tags (preferred_speakers)
-    //           do not map onto expression's situation/topic data model,
-    //           so we reset them and let the user re-pick on the details
-    //           step. When speaking comes back, drop this coercion.
-    const effectiveGoalMode: LearningGoalMode =
-      learningProfile.goal_mode === "pronunciation" ||
-      !learningProfile.goal_mode
-        ? "expression"
-        : learningProfile.goal_mode;
-    setGoalMode(effectiveGoalMode);
+    setGoalMode("expression");
 
-    if (learningProfile.goal_mode === "expression") {
-      const situations =
-        learningProfile.preferred_situations.length > 0
-          ? learningProfile.preferred_situations.filter((item) =>
-              SPEAKING_SITUATIONS.includes(item as SpeakingSituation),
-            )
-          : learningProfile.focus_tags.filter((item) =>
-              SPEAKING_SITUATIONS.includes(item as SpeakingSituation),
-            );
-      const topics =
-        learningProfile.preferred_genres.length > 0
-          ? learningProfile.preferred_genres.filter((item) =>
-              GENRES.includes(item as Genre),
-            )
-          : learningProfile.focus_tags.filter((item) =>
-              GENRES.includes(item as Genre),
-            );
-      setExpressionSituations(situations);
-      setExpressionTopics(topics);
-      setFocusTags(dedupe([...situations, ...topics]));
-    } else {
-      setFocusTags([]);
-      setExpressionSituations([]);
-      setExpressionTopics([]);
-    }
+    // Hydrate v1.3 topic/format selections from focus_tags (prefixed).
+    const tags = learningProfile.focus_tags ?? [];
+    setSelectedTopics(
+      tags
+        .filter((t) => t.startsWith(TOPIC_TAG_PREFIX))
+        .map((t) => t.slice(TOPIC_TAG_PREFIX.length)),
+    );
+    setSelectedFormats(
+      tags
+        .filter((t) => t.startsWith(FORMAT_TAG_PREFIX))
+        .map((t) => t.slice(FORMAT_TAG_PREFIX.length)),
+    );
   }, [learningProfile, user]);
 
-  useEffect(() => {
-    if (goalMode !== "expression") return;
-    setFocusTags(dedupe([...expressionSituations, ...expressionTopics]));
-  }, [expressionSituations, expressionTopics, goalMode]);
-
-  useEffect(() => {
-    if (step !== "details") return;
-
-    if (!goalMode) {
-      // goalMode is always defaulted to "expression" while speaking is
-      // gated, so this path is effectively unreachable. Kept as a safety
-      // net — route back to level instead of the removed goal step.
-      setStep("level");
-    }
-  }, [goalMode, step]);
-
-  const canSubmit = useMemo(() => {
-    if (!level || !goalMode) return false;
-    if (goalMode === "pronunciation") return focusTags.length > 0;
-    return expressionSituations.length > 0 && expressionTopics.length > 0;
-  }, [
-    expressionSituations.length,
-    expressionTopics.length,
-    focusTags.length,
-    goalMode,
-    level,
-  ]);
+  // Each interest step needs at least one selection before advancing.
+  const canLeaveTopics = selectedTopics.length > 0;
+  const canSubmit = useMemo(
+    () =>
+      Boolean(level) && selectedTopics.length > 0 && selectedFormats.length > 0,
+    [level, selectedTopics.length, selectedFormats.length],
+  );
 
   const toggleSelection = (
     value: string,
@@ -849,7 +911,7 @@ export default function OnboardingScreen() {
         level: result.estimatedLevel,
         seedCount: result.seedCount,
       });
-      transitionToStep("details");
+      transitionToStep("topics");
     } catch (error) {
       console.error("[Onboarding] vocab assessment failed:", error);
       // Abandonment / failure → manual level fallback (no garbage persisted).
@@ -863,14 +925,18 @@ export default function OnboardingScreen() {
     if (isSaving || step === "preparing" || vocabSubmitting) return;
     safeImpactLight();
 
-    if (step === "details") {
+    if (step === "formats") {
+      transitionToStep("topics");
+      return;
+    }
+
+    if (step === "topics") {
       transitionToStep(isEditMode ? "level" : "vocab");
       return;
     }
 
     if (step === "level") {
-      // Manual picker is the skip fallback from the vocab test. In edit mode
-      // it is the first step, so back exits the flow.
+      // Manual picker is the vocab-failure fallback / edit-mode entry.
       if (isEditMode) {
         router.back();
       } else {
@@ -880,8 +946,6 @@ export default function OnboardingScreen() {
     }
 
     if (step === "goal") {
-      // Dead fallback: goal step is removed from STEP_SEQUENCE. Kept in
-      // case some future code path lands here, route back to level.
       transitionToStep("level");
       return;
     }
@@ -890,7 +954,7 @@ export default function OnboardingScreen() {
   };
 
   const handleComplete = async () => {
-    if (!user || !goalMode || !level || focusTags.length === 0) return;
+    if (!user || !level || !canSubmit) return;
     safeImpactLight();
 
     cancelPendingStepTransition();
@@ -899,34 +963,24 @@ export default function OnboardingScreen() {
 
     try {
       trackEvent("onboarding_level_selected", { levelBand: level });
-      trackEvent("onboarding_goal_selected", { goalMode, focusTags });
 
+      // Persist v1.3 interest selections in focus_tags (prefixed) for the
+      // assembly wiring (follow-up). Legacy curation fields are left empty.
       await updateLearningProfile({
         level_band: level,
-        goal_mode: goalMode,
-        focus_tags:
-          goalMode === "expression"
-            ? dedupe([...expressionSituations, ...expressionTopics])
-            : [],
-        preferred_speakers: goalMode === "pronunciation" ? focusTags : [],
-        preferred_situations:
-          goalMode === "expression"
-            ? (expressionSituations as SpeakingSituation[])
-            : [],
-        preferred_source_types:
-          goalMode === "expression"
-            ? inferPremiumPreferredSourceTypes({
-                situations: expressionSituations as SpeakingSituation[],
-                genres: expressionTopics as Genre[],
-              })
-            : [],
-        preferred_genres:
-          goalMode === "expression" ? (expressionTopics as Genre[]) : [],
+        goal_mode: "expression",
+        focus_tags: [
+          ...selectedTopics.map((t) => `${TOPIC_TAG_PREFIX}${t}`),
+          ...selectedFormats.map((f) => `${FORMAT_TAG_PREFIX}${f}`),
+        ],
+        preferred_speakers: [],
+        preferred_situations: [],
+        preferred_source_types: [],
+        preferred_genres: [],
         onboarding_completed_at: new Date().toISOString(),
       });
 
       trackEvent("onboarding_complete", {
-        goalMode,
         levelBand: level,
         source: isEditMode ? "settings" : "auth",
       });
@@ -935,7 +989,7 @@ export default function OnboardingScreen() {
     } catch (error) {
       console.error("[Onboarding] Failed to save learning profile:", error);
       cancelPendingStepTransition();
-      setStep("details");
+      setStep("formats");
     } finally {
       setIsSaving(false);
     }
@@ -985,105 +1039,46 @@ export default function OnboardingScreen() {
       );
     }
 
-    if (targetStep === "goal") {
+    if (targetStep === "topics") {
       return (
         <View style={styles.stepBlock}>
-          <Text style={styles.title}>
-            지금 집중하고 싶은 영역은 어느 쪽인가요?
-          </Text>
+          <Text style={styles.title}>어떤 주제에 관심 있으세요?</Text>
           <Text style={styles.body}>
-            선택에 따라 제공해드릴 학습 컨텐츠가 달라져요. 언제든지 바꿀 수
-            있어요.
+            고른 주제로 매일 도착하는 콘텐츠가 맞춰져요. 여러 개 골라도 돼요.
           </Text>
-          <View style={styles.modeRow}>
-            <OptionButton
-              label="발음이나 억양을 개선하고 싶어요"
-              selected={goalMode === "pronunciation"}
-              onPress={() => {
-                setGoalMode("pronunciation");
-                setFocusTags([]);
-                setExpressionSituations([]);
-                setExpressionTopics([]);
-              }}
-            />
-            <OptionButton
-              label="말할 때 쓸 수 있는 표현이 다양해지면 좋겠어요"
-              selected={goalMode === "expression"}
-              onPress={() => {
-                setGoalMode("expression");
-                setFocusTags([]);
-                setExpressionSituations([]);
-                setExpressionTopics([]);
-              }}
-            />
+          <View style={styles.optionList}>
+            {TOPIC_OPTIONS.map((option) => (
+              <MultiSelectRow
+                key={option.value}
+                label={option.label}
+                selected={selectedTopics.includes(option.value)}
+                onPress={() => toggleSelection(option.value, setSelectedTopics)}
+              />
+            ))}
           </View>
         </View>
       );
     }
 
-    if (targetStep === "details") {
+    if (targetStep === "formats") {
       return (
         <View style={styles.stepBlock}>
-          {goalMode === "pronunciation" ? (
-            <View style={styles.focusSection}>
-              <Text style={styles.title}>
-                발음이나 억양 연습을 할 때 선호하는 인물이 있나요?
-              </Text>
-              <Text style={styles.body}>
-                선호도에 맞춰 영상을 추천해드릴게요.
-              </Text>
-              <View style={styles.personGrid}>
-                {PRONUNCIATION_PEOPLE.map((person) => (
-                  <PronunciationPersonCard
-                    key={person.name}
-                    name={person.name}
-                    trait={person.trait}
-                    imageSource={person.imageSource}
-                    selected={focusTags.includes(person.name)}
-                    onPress={() => toggleSelection(person.name, setFocusTags)}
-                  />
-                ))}
-              </View>
-            </View>
-          ) : null}
-
-          {goalMode === "expression" ? (
-            <View style={styles.focusSection}>
-              <Text style={styles.title}>
-                주로 어떤 상황에서 영어를 많이 쓰게 될까요?
-              </Text>
-              <Text style={styles.body}>
-                처음 관심사 클러스터를 잡아두면 매일 도착하는 큐레이션이 더
-                빠르게 맞아져요.
-              </Text>
-              <View style={styles.chipWrap}>
-                {SPEAKING_SITUATIONS.map((tag) => (
-                  <ChoiceChip
-                    key={tag}
-                    label={SPEAKING_SITUATION_LABELS[tag]}
-                    selected={expressionSituations.includes(tag)}
-                    onPress={() =>
-                      toggleSelection(tag, setExpressionSituations)
-                    }
-                  />
-                ))}
-              </View>
-
-              <Text style={[styles.focusTitle, styles.secondaryFocusTitle]}>
-                어떤 주제의 영상들이 있으면 하루라도 더 들어오고 싶어질까요?
-              </Text>
-              <View style={styles.chipWrap}>
-                {GENRES.map((tag) => (
-                  <ChoiceChip
-                    key={tag}
-                    label={GENRE_LABELS[tag]}
-                    selected={expressionTopics.includes(tag)}
-                    onPress={() => toggleSelection(tag, setExpressionTopics)}
-                  />
-                ))}
-              </View>
-            </View>
-          ) : null}
+          <Text style={styles.title}>어떤 스타일을 좋아하세요?</Text>
+          <Text style={styles.body}>
+            같은 주제도 풀어내는 방식이 달라요. 끌리는 형식을 골라주세요.
+          </Text>
+          <View style={styles.optionList}>
+            {FORMAT_OPTIONS.map((option) => (
+              <MultiSelectRow
+                key={option.value}
+                label={option.label}
+                selected={selectedFormats.includes(option.value)}
+                onPress={() =>
+                  toggleSelection(option.value, setSelectedFormats)
+                }
+              />
+            ))}
+          </View>
         </View>
       );
     }
@@ -1176,8 +1171,7 @@ export default function OnboardingScreen() {
                     onPress={() => {
                       if (!level) return;
                       safeImpactLight();
-                      // Skip the goal step (gated off with speaking).
-                      transitionToStep("details");
+                      transitionToStep("topics");
                     }}
                     disabled={!level}
                   >
@@ -1185,25 +1179,25 @@ export default function OnboardingScreen() {
                   </Pressable>
                 ) : null}
 
-                {step === "goal" ? (
+                {step === "topics" ? (
                   <Pressable
-                    accessibilityLabel="학습 목표 다음 단계"
+                    accessibilityLabel="관심 주제 다음 단계"
                     style={[
                       styles.primaryButton,
-                      !goalMode && styles.primaryButtonDisabled,
+                      !canLeaveTopics && styles.primaryButtonDisabled,
                     ]}
                     onPress={() => {
-                      if (!goalMode) return;
+                      if (!canLeaveTopics) return;
                       safeImpactLight();
-                      transitionToStep("details");
+                      transitionToStep("formats");
                     }}
-                    disabled={!goalMode}
+                    disabled={!canLeaveTopics}
                   >
                     <Text style={styles.primaryButtonText}>다음</Text>
                   </Pressable>
                 ) : null}
 
-                {step === "details" ? (
+                {step === "formats" ? (
                   <Pressable
                     accessibilityLabel="온보딩 완료하기"
                     style={[
@@ -1213,9 +1207,7 @@ export default function OnboardingScreen() {
                     onPress={handleComplete}
                     disabled={!canSubmit || isSaving}
                   >
-                    <Text style={styles.primaryButtonText}>
-                      {isEditMode ? "저장하기" : "저장하기"}
-                    </Text>
+                    <Text style={styles.primaryButtonText}>저장하기</Text>
                   </Pressable>
                 ) : null}
               </View>

--- a/apps/mobile/app/onboarding.tsx
+++ b/apps/mobile/app/onboarding.tsx
@@ -45,6 +45,7 @@ import { mediaOverlay } from "@inputenglish/design-tokens";
 import { VocabAssessment } from "@/components/onboarding/VocabAssessment";
 import { submitVocabAssessment } from "@/lib/premium-api";
 import type { VocabAnswer } from "@/lib/premium-api";
+import { safeSelectionAsync, safeImpactLight } from "@/lib/safeHaptic";
 
 type OnboardingStep = "vocab" | "level" | "goal" | "details" | "preparing";
 // @MX:NOTE: "vocab" is the primary first step — a Yes/No vocab-size test
@@ -184,7 +185,10 @@ function OptionButton({
 
   return (
     <Pressable
-      onPress={onPress}
+      onPress={() => {
+        safeSelectionAsync();
+        onPress();
+      }}
       style={({ pressed }) => [
         styles.optionPressable,
         pressed && styles.optionButtonPressed,
@@ -282,7 +286,10 @@ function ChoiceChip({
 
   return (
     <Pressable
-      onPress={onPress}
+      onPress={() => {
+        safeSelectionAsync();
+        onPress();
+      }}
       style={({ pressed }) => [
         styles.chipPressable,
         pressed && styles.chipPressed,
@@ -412,7 +419,10 @@ function PronunciationPersonCard({
 
   return (
     <Pressable
-      onPress={onPress}
+      onPress={() => {
+        safeSelectionAsync();
+        onPress();
+      }}
       style={({ pressed }) => [
         styles.personCardPressable,
         pressed && styles.personCardPressed,
@@ -849,14 +859,9 @@ export default function OnboardingScreen() {
     }
   };
 
-  const handleVocabSkip = () => {
-    if (vocabSubmitting) return;
-    trackEvent("onboarding_vocab_skipped", {});
-    transitionToStep("level");
-  };
-
   const handleBack = () => {
     if (isSaving || step === "preparing" || vocabSubmitting) return;
+    safeImpactLight();
 
     if (step === "details") {
       transitionToStep(isEditMode ? "level" : "vocab");
@@ -886,6 +891,7 @@ export default function OnboardingScreen() {
 
   const handleComplete = async () => {
     if (!user || !goalMode || !level || focusTags.length === 0) return;
+    safeImpactLight();
 
     cancelPendingStepTransition();
     setStep("preparing");
@@ -1116,7 +1122,6 @@ export default function OnboardingScreen() {
           <View style={styles.vocabContainer}>
             <VocabAssessment
               onComplete={handleVocabComplete}
-              onSkip={handleVocabSkip}
               onBack={handleBack}
               submitting={vocabSubmitting}
             />
@@ -1170,6 +1175,7 @@ export default function OnboardingScreen() {
                     ]}
                     onPress={() => {
                       if (!level) return;
+                      safeImpactLight();
                       // Skip the goal step (gated off with speaking).
                       transitionToStep("details");
                     }}
@@ -1188,6 +1194,7 @@ export default function OnboardingScreen() {
                     ]}
                     onPress={() => {
                       if (!goalMode) return;
+                      safeImpactLight();
                       transitionToStep("details");
                     }}
                     disabled={!goalMode}

--- a/apps/mobile/src/__tests__/onboarding-flow.test.tsx
+++ b/apps/mobile/src/__tests__/onboarding-flow.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, waitFor } from "@testing-library/react-native";
+import { act, fireEvent, render, waitFor } from "@testing-library/react-native";
 
 const mockReplace = jest.fn();
 const mockBack = jest.fn();
@@ -36,6 +36,20 @@ jest.mock("../../src/lib/premium-api", () => ({
   submitVocabAssessment: (...args: unknown[]) => mockSubmitVocab(...args),
 }));
 
+// Page through the (mandatory) vocab test and submit, landing on the details
+// step. The button is always "다음"; the final press submits and advances, so we
+// stop once the details title appears (and flush the async submit between taps).
+async function passVocabTest(utils: ReturnType<typeof render>) {
+  for (let i = 0; i < 10; i += 1) {
+    if (utils.queryByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?")) break;
+    const next = utils.queryByText("다음");
+    if (!next) break;
+    fireEvent.press(next);
+    await act(async () => {});
+  }
+  await utils.findByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?");
+}
+
 describe("OnboardingScreen", () => {
   const OnboardingScreen = require("../../app/onboarding").default;
 
@@ -56,23 +70,11 @@ describe("OnboardingScreen", () => {
   });
 
   it("measures the band via the vocab test then advances to details", async () => {
-    const { getByText, queryByText } = render(<OnboardingScreen />);
+    const utils = render(<OnboardingScreen />);
 
-    // Vocab test is the first step. Page through to the end and submit.
-    for (let i = 0; i < 12; i += 1) {
-      const next = queryByText("다음");
-      if (!next) break;
-      fireEvent.press(next);
-    }
-    fireEvent.press(getByText("결과 확인"));
+    await passVocabTest(utils);
 
-    await waitFor(() => {
-      expect(mockSubmitVocab).toHaveBeenCalled();
-      // Advanced to the details step after the server returns the band.
-      expect(
-        getByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?"),
-      ).toBeTruthy();
-    });
+    expect(mockSubmitVocab).toHaveBeenCalled();
   });
 
   it("vocab back goes one page within the test, and exits from the first page", () => {
@@ -93,13 +95,12 @@ describe("OnboardingScreen", () => {
   it("completes onboarding and saves the learning profile with expression as the forced goal", async () => {
     // Speaking/pronunciation is feature-gated on main (see
     // feature/speaking-stability), so the goal step is skipped and
-    // goal_mode is always "expression" at submit time.
-    const { getByText, getByLabelText } = render(<OnboardingScreen />);
+    // goal_mode is always "expression" at submit time. The band comes from the
+    // vocab test (mocked → "conversation").
+    const utils = render(<OnboardingScreen />);
+    const { getByText, getByLabelText } = utils;
 
-    // Skip the vocab test to reach the manual level picker (fallback path).
-    fireEvent.press(getByText("건너뛰고 직접 선택할게요"));
-    fireEvent.press(getByText("일상 회화는 가능해요"));
-    fireEvent.press(getByLabelText("학습 수준 다음 단계"));
+    await passVocabTest(utils);
     fireEvent.press(getByText("학교/업무"));
     fireEvent.press(getByText("업무"));
     fireEvent.press(getByLabelText("온보딩 완료하기"));
@@ -171,13 +172,10 @@ describe("OnboardingScreen", () => {
   it("returns to the details step when saving the profile fails", async () => {
     mockUpdateLearningProfile.mockRejectedValueOnce(new Error("save failed"));
 
-    const { getByText, getByLabelText, findByText } = render(
-      <OnboardingScreen />,
-    );
+    const utils = render(<OnboardingScreen />);
+    const { getByText, getByLabelText, findByText } = utils;
 
-    fireEvent.press(getByText("건너뛰고 직접 선택할게요"));
-    fireEvent.press(getByText("일상 회화는 가능해요"));
-    fireEvent.press(getByLabelText("학습 수준 다음 단계"));
+    await passVocabTest(utils);
     fireEvent.press(getByText("학교/업무"));
     fireEvent.press(getByText("업무"));
     fireEvent.press(getByLabelText("온보딩 완료하기"));

--- a/apps/mobile/src/__tests__/onboarding-flow.test.tsx
+++ b/apps/mobile/src/__tests__/onboarding-flow.test.tsx
@@ -36,18 +36,25 @@ jest.mock("../../src/lib/premium-api", () => ({
   submitVocabAssessment: (...args: unknown[]) => mockSubmitVocab(...args),
 }));
 
-// Page through the (mandatory) vocab test and submit, landing on the details
-// step. The button is always "다음"; the final press submits and advances, so we
-// stop once the details title appears (and flush the async submit between taps).
+// Page through the (mandatory) vocab test; the final "다음" submits the band and
+// lands on the topics step.
 async function passVocabTest(utils: ReturnType<typeof render>) {
   for (let i = 0; i < 10; i += 1) {
-    if (utils.queryByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?")) break;
+    if (utils.queryByText("어떤 주제에 관심 있으세요?")) break;
     const next = utils.queryByText("다음");
     if (!next) break;
     fireEvent.press(next);
     await act(async () => {});
   }
-  await utils.findByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?");
+  await utils.findByText("어떤 주제에 관심 있으세요?");
+}
+
+// On the topics step: pick a topic → next → pick a format → save.
+function selectInterestsAndComplete(utils: ReturnType<typeof render>) {
+  fireEvent.press(utils.getByText("과학"));
+  fireEvent.press(utils.getByText("다음"));
+  fireEvent.press(utils.getByText("정보 / 설명형"));
+  fireEvent.press(utils.getByText("저장하기"));
 }
 
 describe("OnboardingScreen", () => {
@@ -69,11 +76,9 @@ describe("OnboardingScreen", () => {
     mockLearningProfile = null;
   });
 
-  it("measures the band via the vocab test then advances to details", async () => {
+  it("measures the band via the vocab test then advances to topics", async () => {
     const utils = render(<OnboardingScreen />);
-
     await passVocabTest(utils);
-
     expect(mockSubmitVocab).toHaveBeenCalled();
   });
 
@@ -92,97 +97,70 @@ describe("OnboardingScreen", () => {
     expect(mockBack).not.toHaveBeenCalled();
   });
 
-  it("completes onboarding and saves the learning profile with expression as the forced goal", async () => {
-    // Speaking/pronunciation is feature-gated on main (see
-    // feature/speaking-stability), so the goal step is skipped and
-    // goal_mode is always "expression" at submit time. The band comes from the
-    // vocab test (mocked → "conversation").
+  it("completes onboarding and saves v1.3 topic/format interests", async () => {
     const utils = render(<OnboardingScreen />);
-    const { getByText, getByLabelText } = utils;
 
     await passVocabTest(utils);
-    fireEvent.press(getByText("학교/업무"));
-    fireEvent.press(getByText("업무"));
-    fireEvent.press(getByLabelText("온보딩 완료하기"));
+    selectInterestsAndComplete(utils);
 
     await waitFor(() => {
       expect(mockUpdateLearningProfile).toHaveBeenCalledWith({
         level_band: "conversation",
         goal_mode: "expression",
-        focus_tags: ["school-work", "business"],
+        focus_tags: ["topic:science", "format:nonfiction"],
         preferred_speakers: [],
-        preferred_situations: ["school-work"],
-        preferred_source_types: [
-          "public-speech",
-          "interview",
-          "podcast",
-          "keynote",
-        ],
-        preferred_genres: ["business"],
+        preferred_situations: [],
+        preferred_source_types: [],
+        preferred_genres: [],
         onboarding_completed_at: expect.any(String),
       });
       expect(mockReplace).toHaveBeenCalledWith("/(tabs)");
     });
   });
 
-  it("coerces a legacy pronunciation profile into expression on edit", async () => {
-    // Existing profiles with goal_mode = "pronunciation" from before the
-    // feature gate must be migrated on the fly: the speaker selections
-    // do not map onto expression's situation/topic model, so we reset
-    // them and require the user to pick expression-specific details.
+  it("saves from edit mode starting at the manual level picker", async () => {
     mockParams = { edit: "1" };
     mockLearningProfile = {
       user_id: "user-1",
       level_band: "professional",
-      goal_mode: "pronunciation",
-      focus_tags: ["Jensen Huang"],
-      preferred_speakers: ["Jensen Huang"],
+      goal_mode: "expression",
+      focus_tags: [],
+      preferred_speakers: [],
       preferred_situations: [],
       preferred_source_types: [],
       preferred_genres: [],
       onboarding_completed_at: null,
     };
 
-    const { getByText, getByLabelText } = render(<OnboardingScreen />);
+    const utils = render(<OnboardingScreen />);
 
-    fireEvent.press(getByLabelText("학습 수준 다음 단계"));
-    fireEvent.press(getByText("학교/업무"));
-    fireEvent.press(getByText("업무"));
-    fireEvent.press(getByText("저장하기"));
+    // Edit mode starts at the manual level picker (level is hydrated).
+    fireEvent.press(utils.getByLabelText("학습 수준 다음 단계"));
+    selectInterestsAndComplete(utils);
 
     await waitFor(() => {
       expect(mockUpdateLearningProfile).toHaveBeenCalledWith({
         level_band: "professional",
         goal_mode: "expression",
-        focus_tags: ["school-work", "business"],
+        focus_tags: ["topic:science", "format:nonfiction"],
         preferred_speakers: [],
-        preferred_situations: ["school-work"],
-        preferred_source_types: [
-          "public-speech",
-          "interview",
-          "podcast",
-          "keynote",
-        ],
-        preferred_genres: ["business"],
+        preferred_situations: [],
+        preferred_source_types: [],
+        preferred_genres: [],
         onboarding_completed_at: expect.any(String),
       });
     });
   });
 
-  it("returns to the details step when saving the profile fails", async () => {
+  it("returns to the formats step when saving the profile fails", async () => {
     mockUpdateLearningProfile.mockRejectedValueOnce(new Error("save failed"));
 
     const utils = render(<OnboardingScreen />);
-    const { getByText, getByLabelText, findByText } = utils;
 
     await passVocabTest(utils);
-    fireEvent.press(getByText("학교/업무"));
-    fireEvent.press(getByText("업무"));
-    fireEvent.press(getByLabelText("온보딩 완료하기"));
+    selectInterestsAndComplete(utils);
 
-    expect(
-      await findByText("주로 어떤 상황에서 영어를 많이 쓰게 될까요?"),
-    ).toBeTruthy();
+    expect(await utils.findByText("어떤 스타일을 좋아하세요?")).toBeTruthy();
     expect(mockReplace).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/components/onboarding/VocabAssessment.tsx
+++ b/apps/mobile/src/components/onboarding/VocabAssessment.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator,
+  Animated,
   Pressable,
   ScrollView,
   Text,
@@ -11,6 +12,13 @@ import { buildAssessmentItems } from "@inputenglish/shared";
 import type { AssessmentItem } from "@inputenglish/shared";
 import { useTheme, createThemedStyles } from "@/components/ui";
 import type { VocabAnswer } from "@/lib/premium-api";
+import { safeSelectionAsync, safeImpactLight } from "@/lib/safeHaptic";
+
+// Green for a selected ("known") word — no green token in the design system yet.
+const SELECTED_WORD_COLOR = "#22C55E";
+// Scale a word pops to when selected — bouncy spring for a game-like feel.
+const SELECTED_SCALE = 1.18;
+const IS_TEST_ENV = process.env.NODE_ENV === "test";
 
 // @MX:NOTE: Onboarding Yes/No vocab-size test (SPEC-INPUT-003 REQ-VOCAB-A/I).
 // Items are sampled client-side from the shared frequency list; the SERVER is
@@ -29,9 +37,61 @@ function chunk<T>(arr: T[], size: number): T[][] {
   return pages;
 }
 
+// A single word. Springs up in scale (and turns green via style) when selected,
+// for a tactile, game-like selection.
+function WordItem({
+  token,
+  isKnown,
+  onPress,
+}: {
+  token: string;
+  isKnown: boolean;
+  onPress: () => void;
+}) {
+  const theme = useTheme();
+  const styles = getStyles(theme);
+  const scale = useRef(
+    new Animated.Value(isKnown ? SELECTED_SCALE : 1),
+  ).current;
+
+  useEffect(() => {
+    if (IS_TEST_ENV) {
+      scale.setValue(isKnown ? SELECTED_SCALE : 1);
+      return;
+    }
+    Animated.spring(scale, {
+      toValue: isKnown ? SELECTED_SCALE : 1,
+      useNativeDriver: true,
+      friction: 5,
+      tension: 200,
+    }).start();
+  }, [isKnown, scale]);
+
+  return (
+    <Pressable
+      accessibilityLabel={`단어 ${token}`}
+      accessibilityState={{ selected: isKnown }}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.wordCell,
+        pressed && styles.wordCellPressed,
+      ]}
+    >
+      <Animated.Text
+        style={[
+          styles.wordText,
+          isKnown && styles.wordTextKnown,
+          { transform: [{ scale }] },
+        ]}
+      >
+        {token}
+      </Animated.Text>
+    </Pressable>
+  );
+}
+
 interface VocabAssessmentProps {
   onComplete: (answers: VocabAnswer[]) => void;
-  onSkip: () => void;
   /** Called when back is pressed on the first page (exit the test). */
   onBack: () => void;
   submitting?: boolean;
@@ -41,7 +101,6 @@ interface VocabAssessmentProps {
 
 export function VocabAssessment({
   onComplete,
-  onSkip,
   onBack,
   submitting = false,
   seed,
@@ -68,14 +127,17 @@ export function VocabAssessment({
   // token -> known (default: not known). User taps words they recognize.
   const [known, setKnown] = useState<Record<string, boolean>>({});
 
-  const toggle = (token: string) =>
+  const toggle = (token: string) => {
+    safeSelectionAsync();
     setKnown((prev) => ({ ...prev, [token]: !prev[token] }));
+  };
 
   const isLastPage = pageIndex === pages.length - 1;
   const progress = (pageIndex + 1) / pages.length;
 
   const handleNext = () => {
     if (submitting) return;
+    safeImpactLight();
     if (!isLastPage) {
       setPageIndex((p) => p + 1);
       return;
@@ -90,6 +152,7 @@ export function VocabAssessment({
   // Back goes one page within the test; from the first page it exits via onBack.
   const handleBackPress = () => {
     if (submitting) return;
+    safeImpactLight();
     if (pageIndex > 0) {
       setPageIndex((p) => p - 1);
       return;
@@ -133,27 +196,19 @@ export function VocabAssessment({
         contentContainerStyle={styles.wordGrid}
         showsVerticalScrollIndicator={false}
       >
-        {currentPage.map((item) => {
-          const isKnown = Boolean(known[item.token]);
-          return (
-            <Pressable
-              key={item.token}
-              accessibilityLabel={`단어 ${item.token}`}
-              accessibilityState={{ selected: isKnown }}
-              onPress={() => toggle(item.token)}
-              style={[styles.wordChip, isKnown && styles.wordChipKnown]}
-            >
-              <Text style={[styles.wordText, isKnown && styles.wordTextKnown]}>
-                {item.token}
-              </Text>
-            </Pressable>
-          );
-        })}
+        {currentPage.map((item) => (
+          <WordItem
+            key={item.token}
+            token={item.token}
+            isKnown={Boolean(known[item.token])}
+            onPress={() => toggle(item.token)}
+          />
+        ))}
       </ScrollView>
 
       <View style={styles.footer}>
         <Pressable
-          accessibilityLabel={isLastPage ? "어휘 평가 제출" : "다음 단어 묶음"}
+          accessibilityLabel="다음"
           onPress={handleNext}
           disabled={submitting}
           style={[styles.primaryButton, submitting && styles.buttonDisabled]}
@@ -161,19 +216,8 @@ export function VocabAssessment({
           {submitting ? (
             <ActivityIndicator color={theme.colors.text.inverse} />
           ) : (
-            <Text style={styles.primaryButtonText}>
-              {isLastPage ? "결과 확인" : "다음"}
-            </Text>
+            <Text style={styles.primaryButtonText}>다음</Text>
           )}
-        </Pressable>
-
-        <Pressable
-          accessibilityLabel="테스트 건너뛰고 직접 선택"
-          onPress={onSkip}
-          disabled={submitting}
-          style={styles.skipButton}
-        >
-          <Text style={styles.skipText}>건너뛰고 직접 선택할게요</Text>
         </Pressable>
       </View>
     </View>
@@ -227,27 +271,32 @@ const getStyles = createThemedStyles((theme) => ({
   wordGrid: {
     flexDirection: "row" as const,
     flexWrap: "wrap" as const,
-    gap: theme.spacing[2],
+    justifyContent: "space-between" as const,
+    rowGap: theme.spacing[3],
     paddingBottom: theme.spacing[4],
   },
-  wordChip: {
-    borderRadius: theme.radius.full,
-    borderWidth: 1,
-    borderColor: theme.colors.border.default,
-    backgroundColor: theme.colors.surface.muted,
-    paddingHorizontal: theme.spacing[4],
-    paddingVertical: 10,
+  // Big text-only words in a 2-column layout (no chip box). Selection is shown
+  // by green colour + bold + a spring scale-up. Generous vertical padding keeps
+  // the tap target large even though only the glyphs are visible.
+  wordCell: {
+    width: "48%" as const,
+    paddingVertical: theme.spacing[3],
+    alignItems: "center" as const,
   },
-  wordChipKnown: {
-    borderColor: theme.colors.action.primary,
-    backgroundColor: theme.colors.action.primary,
+  wordCellPressed: {
+    opacity: 0.6,
   },
   wordText: {
-    ...theme.typography.bodyStrong,
-    color: theme.colors.text.primary,
+    fontSize: 22,
+    lineHeight: 30,
+    fontWeight: "500" as const,
+    color: theme.colors.text.secondary,
+    textAlign: "center" as const,
   },
+  // Selected word: green + bold (no underline) per design feedback.
   wordTextKnown: {
-    color: theme.colors.text.inverse,
+    color: SELECTED_WORD_COLOR,
+    fontWeight: "700" as const,
   },
   footer: {
     gap: theme.spacing[2],
@@ -265,13 +314,5 @@ const getStyles = createThemedStyles((theme) => ({
   primaryButtonText: {
     ...theme.typography.button,
     color: theme.colors.text.inverse,
-  },
-  skipButton: {
-    alignItems: "center" as const,
-    paddingVertical: theme.spacing[2],
-  },
-  skipText: {
-    ...theme.typography.label,
-    color: theme.colors.text.secondary,
   },
 }));

--- a/apps/mobile/src/lib/safeHaptic.ts
+++ b/apps/mobile/src/lib/safeHaptic.ts
@@ -35,3 +35,13 @@ export function safeImpactAsync(style: Haptics.ImpactFeedbackStyle): void {
     // Silently ignore — haptics are an enhancement, not a requirement.
   }
 }
+
+/** Fire-and-forget Light impact — use for button/nav taps. */
+export function safeImpactLight(): void {
+  safeImpactAsync(Haptics.ImpactFeedbackStyle.Light);
+}
+
+/** Fire-and-forget Medium impact — use for page/step transitions. */
+export function safeImpactMedium(): void {
+  safeImpactAsync(Haptics.ImpactFeedbackStyle.Medium);
+}


### PR DESCRIPTION
## Onboarding polish + v1.3-aligned interests

Three commits:
1. **Design** — words: chip pills → big 2-column text, selected = green + bold + spring scale-up (game-like); haptics on every tap; skip removed (everyone takes the test); last-page button "결과 확인" → "다음".
2. **Interests → v1.3** — replaced the legacy speaking-situation / genre questions (which fed the frozen premium curation, not v1.3) with two v1.3-aligned pages: **topics** (science, technology, economics, health, education, culture, history, climate) + **formats** (nonfiction, editorial, dialogue, noir, business, economic), as full-width multi-select rows. Persisted in `focus_tags` (`topic:`/`format:` prefixed).
3. **Cleanup** — dropped the now-dead legacy surface (PronunciationPersonCard, ChoiceChip, goal step, goalMode, unused imports/styles). onboarding.tsx 1140 → 838 lines.

Mobile jest 272 pass, tsc 0.

> Backend wiring (making the collected `focus_tags` actually filter v1.3 reading-pool / segment selection) follows in a separate PR.